### PR TITLE
feat: API documentation with OpenAPI 3.1 + Scalar UI

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -5,6 +5,10 @@ const config: Config = {
   testEnvironment: "node",
   testMatch: ["<rootDir>/tests/**/*.test.ts"],
   moduleFileExtensions: ["ts", "js", "json"],
+  moduleNameMapper: {
+    "^@scalar/express-api-reference$":
+      "<rootDir>/tests/__mocks__/@scalar/express-api-reference.ts",
+  },
 };
 
 export default config;

--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -1,5 +1,5 @@
 {
   "watch": ["src"],
-  "ext": "ts",
+  "ext": "ts,yaml",
   "exec": "ts-node src/index.ts"
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@scalar/express-api-reference": "^0.8.44",
         "axios": "^1.13.5",
         "cors": "^2.8.6",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "yaml": "^2.8.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -1076,6 +1078,69 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@scalar/core": {
+      "version": "0.3.41",
+      "resolved": "https://registry.npmjs.org/@scalar/core/-/core-0.3.41.tgz",
+      "integrity": "sha512-IPgiHOSGBDfBcJELbev0lo+ZHc8Q/vA82neX0Ax1iHNGtf/munH+qN5I+p9rGRS60IRQAwABlUo31Y3Gw1c0EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/types": "0.6.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/express-api-reference": {
+      "version": "0.8.44",
+      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.8.44.tgz",
+      "integrity": "sha512-T1rfrtCv8R83iSyhIIhJQLDEOXgylV4T1GxkmlfUQvptGbA7LVcFInTB4eBHae17OiQzx5xoCoDr/1GAVhEoxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/core": "0.3.41"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/helpers": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.2.15.tgz",
+      "integrity": "sha512-hMHXejGFVOS4HwCo7C2qddChuvMJs3sEOALo7gNOvwLS4dGLrW8flbSglDki4ttyremlKQstP5WJuPxmHQU3sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/types": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.6.6.tgz",
+      "integrity": "sha512-nr3m23p5MnGy4Wb4JFT7aA+jzvYSs/AS40NUEoQMBE1IwtuvG5gtLL0uu6kWpDq4UAfrWGntlAQNX7G8X9D4sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.2.15",
+        "nanoid": "^5.1.6",
+        "type-fest": "^5.3.1",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@scalar/types/node_modules/type-fest": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
+      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4445,6 +4510,24 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -5559,6 +5642,18 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -6140,6 +6235,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -6235,6 +6345,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "nodemon",
-    "build": "tsc",
+    "build": "tsc && mkdir -p dist/docs && cp src/docs/openapi.yaml dist/docs/openapi.yaml",
     "start": "node dist/index.js",
     "test": "jest",
     "test:watch": "jest --watch"
@@ -14,9 +14,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@scalar/express-api-reference": "^0.8.44",
     "axios": "^1.13.5",
     "cors": "^2.8.6",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -1,0 +1,9 @@
+import fs from "fs";
+import path from "path";
+import { parse } from "yaml";
+
+const specPath = path.join(__dirname, "openapi.yaml");
+const specFile = fs.readFileSync(specPath, "utf-8");
+const openApiSpec = parse(specFile);
+
+export default openApiSpec;

--- a/backend/src/docs/openapi.yaml
+++ b/backend/src/docs/openapi.yaml
@@ -1,0 +1,282 @@
+openapi: "3.1.0"
+info:
+  title: Metal Setlist Builder API
+  description: |
+    Backend API for Metal Setlist Builder.
+    Proxies data from MusicBrainz to search artists, browse albums, and list tracks.
+  version: "1.0.0"
+
+servers:
+  - url: http://localhost:3000
+    description: Local development server
+
+tags:
+  - name: Health
+    description: Service health check
+  - name: Artists
+    description: Artist search via MusicBrainz
+  - name: Albums
+    description: Albums (release groups) by artist
+  - name: Tracks
+    description: Tracks (recordings) by release group
+
+paths:
+  /health:
+    get:
+      operationId: healthCheck
+      tags: [Health]
+      summary: Health check
+      description: Returns the service status.
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              example:
+                status: ok
+
+  /api/artists/search:
+    get:
+      operationId: searchArtists
+      tags: [Artists]
+      summary: Search artists
+      description: |
+        Searches MusicBrainz for artists matching the query string.
+        Returns up to 25 results sorted by relevance.
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search query (artist name)
+          schema:
+            type: string
+            minLength: 1
+          example: Slayer
+      responses:
+        "200":
+          description: List of matching artists
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ArtistSearchResult"
+              example:
+                - id: "934e8258-cd8a-4e8a-b32d-f1a2b0560f10"
+                  name: Slayer
+                  country: US
+                  disambiguation: "thrash metal band"
+        "400":
+          description: Missing or empty query parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+              example:
+                error: "Query parameter 'q' is required"
+        "502":
+          $ref: "#/components/responses/MusicBrainzUnavailable"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/artists/{id}/albums:
+    get:
+      operationId: getAlbumsByArtist
+      tags: [Albums]
+      summary: Get albums by artist
+      description: |
+        Returns all studio albums (release groups of type "Album") for the given
+        artist ID. Results are filtered to primary releases, sorted by year
+        (ascending), and cached for 5 minutes.
+      parameters:
+        - $ref: "#/components/parameters/MusicBrainzId"
+      responses:
+        "200":
+          description: List of albums for the artist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AlbumResult"
+              example:
+                - id: "e4dadfc0-e43b-31f4-9fba-55c9f7dfbb58"
+                  title: Reign in Blood
+                  year: 1986
+                  coverUrl: "https://coverartarchive.org/release-group/e4dadfc0-e43b-31f4-9fba-55c9f7dfbb58/front-250"
+        "400":
+          description: Invalid ID format (must be a UUID)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+              example:
+                error: "Invalid ID format"
+        "404":
+          description: Artist not found on MusicBrainz
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+              example:
+                error: "Resource not found on MusicBrainz"
+        "502":
+          $ref: "#/components/responses/MusicBrainzUnavailable"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/albums/{id}/tracks:
+    get:
+      operationId: getTracksByAlbum
+      tags: [Tracks]
+      summary: Get tracks by album
+      description: |
+        Returns all tracks for the given release group ID. Performs a 2-step
+        lookup: first fetches releases in the group, then retrieves the track
+        listing from the first release. Results are cached for 5 minutes.
+      parameters:
+        - $ref: "#/components/parameters/MusicBrainzId"
+      responses:
+        "200":
+          description: List of tracks for the album
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TrackResult"
+              example:
+                - id: "b1e1b28c-3ff3-4087-a881-b1ef88d7c2e0"
+                  title: Angel of Death
+                  position: 1
+                  duration: "4:51"
+                  disc: 1
+        "400":
+          description: Invalid ID format (must be a UUID)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+              example:
+                error: "Invalid ID format"
+        "404":
+          description: Release group not found on MusicBrainz
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiErrorResponse"
+              example:
+                error: "Resource not found on MusicBrainz"
+        "502":
+          $ref: "#/components/responses/MusicBrainzUnavailable"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          example: ok
+
+    ArtistSearchResult:
+      type: object
+      required: [id, name, country, disambiguation]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: MusicBrainz artist ID
+        name:
+          type: string
+          description: Artist name
+        country:
+          type: ["string", "null"]
+          description: ISO 3166-1 country code
+        disambiguation:
+          type: ["string", "null"]
+          description: Extra info to distinguish similarly named artists
+
+    AlbumResult:
+      type: object
+      required: [id, title, year, coverUrl]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: MusicBrainz release group ID
+        title:
+          type: string
+          description: Album title
+        year:
+          type: ["integer", "null"]
+          description: Release year
+        coverUrl:
+          type: string
+          format: uri
+          description: Cover art URL (250px)
+
+    TrackResult:
+      type: object
+      required: [id, title, position, duration, disc]
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: MusicBrainz recording ID
+        title:
+          type: string
+          description: Track title
+        position:
+          type: integer
+          description: Track position in the disc
+        duration:
+          type: ["string", "null"]
+          description: "Formatted duration (e.g. \"4:51\")"
+        disc:
+          type: integer
+          description: Disc number
+
+    ApiErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          description: Human-readable error message
+
+  parameters:
+    MusicBrainzId:
+      name: id
+      in: path
+      required: true
+      description: MusicBrainz UUID
+      schema:
+        type: string
+        format: uuid
+        pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+      example: "e4dadfc0-e43b-31f4-9fba-55c9f7dfbb58"
+
+  responses:
+    MusicBrainzUnavailable:
+      description: MusicBrainz API is temporarily unavailable
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiErrorResponse"
+          example:
+            error: "MusicBrainz temporarily unavailable"
+
+    InternalError:
+      description: Unexpected server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiErrorResponse"
+          example:
+            error: "Internal server error"

--- a/backend/src/routes/docsRoutes.ts
+++ b/backend/src/routes/docsRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from "express";
+import { apiReference } from "@scalar/express-api-reference";
+import openApiSpec from "../docs/openapi";
+
+const router = Router();
+
+router.get("/api/docs/openapi.json", (_req: Request, res: Response) => {
+  res.json(openApiSpec);
+});
+
+router.get(
+  "/api/docs",
+  apiReference({
+    content: openApiSpec,
+    theme: "moon",
+  })
+);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -3,6 +3,7 @@ import healthRoutes from "./healthRoutes";
 import artistRoutes from "./artistRoutes";
 import albumRoutes from "./albumRoutes";
 import trackRoutes from "./trackRoutes";
+import docsRoutes from "./docsRoutes";
 
 const router = Router();
 
@@ -10,5 +11,6 @@ router.use(healthRoutes);
 router.use("/api", artistRoutes);
 router.use("/api", albumRoutes);
 router.use("/api", trackRoutes);
+router.use(docsRoutes);
 
 export default router;

--- a/backend/tests/__mocks__/@scalar/express-api-reference.ts
+++ b/backend/tests/__mocks__/@scalar/express-api-reference.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from "express";
+
+export function apiReference() {
+  return (_req: Request, res: Response) => {
+    res.setHeader("Content-Type", "text/html");
+    res.send("<html><body>Scalar API Reference</body></html>");
+  };
+}

--- a/backend/tests/integration/docs.test.ts
+++ b/backend/tests/integration/docs.test.ts
@@ -1,0 +1,42 @@
+import request from "supertest";
+import { createApp } from "../../src/app";
+
+const app = createApp();
+
+describe("API Documentation", () => {
+  describe("GET /api/docs/openapi.json", () => {
+    it("should return 200 with OpenAPI 3.1.0 spec", async () => {
+      const res = await request(app).get("/api/docs/openapi.json");
+      expect(res.status).toBe(200);
+      expect(res.body.openapi).toBe("3.1.0");
+      expect(res.body.info.title).toBe("Metal Setlist Builder API");
+    });
+
+    it("should contain all API paths", async () => {
+      const res = await request(app).get("/api/docs/openapi.json");
+      const paths = Object.keys(res.body.paths);
+      expect(paths).toContain("/health");
+      expect(paths).toContain("/api/artists/search");
+      expect(paths).toContain("/api/artists/{id}/albums");
+      expect(paths).toContain("/api/albums/{id}/tracks");
+    });
+
+    it("should define all component schemas", async () => {
+      const res = await request(app).get("/api/docs/openapi.json");
+      const schemas = Object.keys(res.body.components.schemas);
+      expect(schemas).toContain("HealthResponse");
+      expect(schemas).toContain("ArtistSearchResult");
+      expect(schemas).toContain("AlbumResult");
+      expect(schemas).toContain("TrackResult");
+      expect(schemas).toContain("ApiErrorResponse");
+    });
+  });
+
+  describe("GET /api/docs", () => {
+    it("should return 200 with HTML (Scalar UI)", async () => {
+      const res = await request(app).get("/api/docs");
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/html/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add interactive API documentation at `/api/docs` using **Scalar** with dark "moon" theme
- Serve raw OpenAPI 3.1 spec at `/api/docs/openapi.json` for tooling (Postman, CI validation)
- Full spec covering all 4 endpoints with schemas matching `src/types/api.ts`, reusable components, and real-world examples (Slayer, Reign in Blood, Angel of Death)

## Changes
| File | Description |
|---|---|
| `src/docs/openapi.yaml` | Complete OpenAPI 3.1 specification |
| `src/docs/openapi.ts` | YAML loader (reads spec at startup) |
| `src/routes/docsRoutes.ts` | Routes for Scalar UI + JSON endpoint |
| `src/routes/index.ts` | Register docs routes |
| `jest.config.ts` | Mock for ESM-only `@scalar/express-api-reference` |
| `tests/__mocks__/` | Manual Jest mock for Scalar |
| `tests/integration/docs.test.ts` | 4 integration tests for docs endpoints |
| `nodemon.json` | Watch `.yaml` files for dev reload |
| `package.json` | New deps + build script copies YAML to dist |

## Test plan
- [x] All 47 tests pass (43 existing + 4 new)
- [ ] `npm run dev` → open `http://localhost:3000/api/docs` — verify Scalar UI with dark theme
- [ ] `http://localhost:3000/api/docs/openapi.json` — verify valid JSON spec
- [ ] Test endpoints interactively via Scalar's API client

## Closes
Closes #1
Closes #3
Closes #6
Closes #9